### PR TITLE
Fixed name of geom_rangeframe in README documentation

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -10,7 +10,7 @@ Some extra geoms, scales, and themes for
 
 ## Geoms
 
-- ``geom_tufterangeframe`` : Tufte's range frame
+- ``geom_rangeframe`` : Tufte's range frame
 - ``geom_tufteboxplot``: Tufte's box plot
 
 ## Themes 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Some extra geoms, scales, and themes for
 
 ## Geoms
 
-- ``geom_tufterangeframe`` : Tufte's range frame
+- ``geom_rangeframe`` : Tufte's range frame
 - ``geom_tufteboxplot``: Tufte's box plot
 
 ## Themes 


### PR DESCRIPTION
It was geom_tufterangeframe which doesn't match the code. 

On a tangential note it is now inconsistent with the geom_tufteboxplot.
