### PR TITLE
Adding support for the 'other' Tufte boxplot

### DIFF
--- a/R/geom-tufteboxplot.R
+++ b/R/geom-tufteboxplot.R
@@ -130,9 +130,9 @@ GeomTufteboxplot <- proto(ggplot2:::Geom, {
       
       # scale the offset by the size parameter
       x0_offset <- c(rep(offset * common$size, 2),
-                     rep(offset * common$size * 1.3, 2)) 
+                     rep(offset * common$size * 1.2, 2))
       x1_offset <- c(rep(offset * common$size, 2), 
-                     rep(offset * common$size / -2.5, 2))
+                     rep(offset * common$size / -5, 2))
       
       # shift the points at the median so there will be whitespace
       y_offset <- c(1.5 * offset, -1.5 * offset, 0, 0)


### PR DESCRIPTION
... as an option to geom-tufteboxplot. This also replaces the 'usebox' option with a new 'median.type' option that can toggle the median being represented as a point (default, median.type='point'), a box (the old 'usebox=TRUE', median.type='box') or a line (median.type='line').
