### PR TITLE
add scale_fill functions

### DIFF
--- a/R/fivethirtyeight.R
+++ b/R/fivethirtyeight.R
@@ -71,3 +71,9 @@ scale_colour_fivethirtyeight <- function(...) {
 #' @rdname scale_fivethirtyeight
 #' @export
 scale_color_fivethirtyeight <- scale_colour_fivethirtyeight
+
+##' @rdname scale_fivethirtyeight
+##' @export
+scale_fill_fivethirtyeight <- function(...) {
+    discrete_scale("fill", "economist", fivethirtyeight_pal(), ...)
+}

--- a/R/tableau.R
+++ b/R/tableau.R
@@ -146,7 +146,7 @@ tableau_seq_gradient_pal <- function(palette = "Red", space = "Lab") {
 
 
 #' Tableau sequential colour scale (continuous)
-#' 
+#'
 #' @export
 #' @inheritParams tableau_seq_gradient_pal
 #' @inheritParams ggplot2::scale_colour_hue
@@ -160,7 +160,7 @@ tableau_seq_gradient_pal <- function(palette = "Red", space = "Lab") {
 #' d + scale_colour_gradient_tableau("Red", limits=c(3, 4))
 #' d + scale_colour_gradient_tableau("Blue", limits=c(3, 4))
 #' d + scale_colour_gradient_tableau("Green", limits=c(3, 4))
-scale_colour_gradient_tableau <- function (palette = "Red", ..., space = "Lab", 
+scale_colour_gradient_tableau <- function (palette = "Red", ..., space = "Lab",
     na.value = "grey50", guide = "colourbar") {
     continuous_scale("colour", "tableau",
                      tableau_seq_gradient_pal(palette, space), na.value = na.value, guide = guide, ...)
@@ -168,7 +168,7 @@ scale_colour_gradient_tableau <- function (palette = "Red", ..., space = "Lab",
 
 #' @export
 #' @rdname scale_colour_gradient_tableau
-scale_fill_gradient_tableau <- function (palette = "Red", ..., space = "Lab", 
+scale_fill_gradient_tableau <- function (palette = "Red", ..., space = "Lab",
     na.value = "grey50", guide = "colourbar") {
     continuous_scale("fill", "tableau",
                      tableau_seq_gradient_pal(palette, space), na.value = na.value, guide = guide, ...)
@@ -181,6 +181,10 @@ scale_color_gradient_tableau <- scale_colour_gradient_tableau
 #' @export
 #' @rdname scale_colour_gradient_tableau
 scale_color_continuous_tableau <- scale_colour_gradient_tableau
+
+#' @export
+#' @rdname scale_colour_gradient_tableau
+scale_fill_continuous_tableau <- scale_fill_gradient_tableau
 
 
 #' Tableau diverging colour gradient palettes (continuous)
@@ -203,7 +207,7 @@ tableau_div_gradient_pal <- function(palette = "Red-Blue", space = "Lab") {
 }
 
 #' Tableau diverging colour scales (continuous)
-#' 
+#'
 #' @inheritParams tableau_div_gradient_pal
 #' @inheritParams ggplot2::scale_colour_hue
 #' @param guide Type of legend. Use \code{"colourbar"} for continuous
@@ -218,7 +222,7 @@ tableau_div_gradient_pal <- function(palette = "Red-Blue", space = "Lab") {
 #' d + scale_colour_gradient2_tableau()
 #' d + scale_colour_gradient2_tableau("Orange-Blue")
 #' d + scale_colour_gradient2_tableau("Temperature")
-scale_colour_gradient2_tableau <- function (palette = "Red-Blue", ..., space = "rgb", 
+scale_colour_gradient2_tableau <- function (palette = "Red-Blue", ..., space = "rgb",
     na.value = "grey50", guide = "colourbar") {
     continuous_scale("colour", "tableau2",
                      tableau_div_gradient_pal(palette, space), na.value = na.value, guide = guide, ...)
@@ -226,7 +230,7 @@ scale_colour_gradient2_tableau <- function (palette = "Red-Blue", ..., space = "
 
 #' @export
 #' @rdname scale_colour_gradient2_tableau
-scale_fill_gradient2_tableau <- function (palette = "Red-Blue", ..., space = "rgb", 
+scale_fill_gradient2_tableau <- function (palette = "Red-Blue", ..., space = "rgb",
     na.value = "grey50", guide = "colourbar") {
     continuous_scale("fill", "tableau2",
                      tableau_div_gradient_pal(palette, space), na.value = na.value, guide = guide, ...)

--- a/R/wsj.R
+++ b/R/wsj.R
@@ -82,7 +82,7 @@ theme_wsj <- function(base_size=12, color="brown", base_family="sans", title_fam
 ##'
 ##' @family colour wsj
 ##' @export
-wsj_pal <- function(palette) {
+wsj_pal <- function(palette="colors6") {
     if (palette %in% names(ggthemes_data$wsj$palettes)) {
         manual_pal(unname(ggthemes_data$wsj$palettes[[palette]]))
     } else {
@@ -101,7 +101,7 @@ wsj_pal <- function(palette) {
 ##' @family colour wsj
 ##' @rdname scale_wsj
 ##' @export
-scale_colour_wsj <- function(palette, ...) {
+scale_colour_wsj <- function(palette="colors6", ...) {
     discrete_scale("colour", "wsj", wsj_pal(palette), ...)
 }
 
@@ -111,7 +111,7 @@ scale_color_wsj <- scale_colour_wsj
 
 ##' @rdname scale_wsj
 ##' @export
-scale_fill_wsj <- function(palette, ...) {
+scale_fill_wsj <- function(palette="colors6", ...) {
     discrete_scale("fill", "wsj", wsj_pal(palette), ...)
 }
 


### PR DESCRIPTION
Hi Jeffrey -
only small changes, please feel free to refuse

See email from 18 September:
Hi Jeffrey,

thanks for this package - good initiative!

I was testing the examples at https://github.com/jrnold/ggthemes with a bar chart and realized the scale_fill_fivethirtyeight() was missing - it's a minor modification but I don't know github well enough to implement the change myself (except forking etc)

let me know your suggestion,

thanks,
Bo
