### PR TITLE
Typo fix: theme_wsj is based on The Wall Street Journal and not on The Economist

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Some extra geoms, scales, and themes for
 - ``theme_solarized``: a theme using the [solarized](http://ethanschoonover.com/solarized) color palette.
 - ``theme_stata``: themes based on [Stata](http://stata.com/) graph schemes.
 - ``theme_tufte``: a minimal ink theme based on Tufte's *The Visual Display of Quantitative Information*.
-- ``theme_wsj``: a theme based on the plots in the [The Economist](http://www.economist.com/) magazine.
+- ``theme_wsj``: a theme based on the plots in the [The Wall Street Journal](http://www.wsj.com/).
 
 ### Scales
 

--- a/vignettes/children/intro.Rmd
+++ b/vignettes/children/intro.Rmd
@@ -21,7 +21,7 @@ Some extra geoms, scales, and themes for
 - ``theme_solarized``: a theme using the [solarized](http://ethanschoonover.com/solarized) color palette.
 - ``theme_stata``: themes based on [Stata](http://stata.com/) graph schemes.
 - ``theme_tufte``: a minimal ink theme based on Tufte's *The Visual Display of Quantitative Information*.
-- ``theme_wsj``: a theme based on the plots in the [The Economist](http://www.economist.com/) magazine.
+- ``theme_wsj``: a theme based on the plots in the [The Wall Street Journal](http://www.wsj.com/).
 
 ### Scales
 


### PR DESCRIPTION
Note: I couldn't build the vignettes from source. Code was failing in examples.Rmd. So, I edited the README.md manually. 