### PR TITLE
Stops gdocs.R from drawing a border around a legend

### DIFF
--- a/R/gdocs.R
+++ b/R/gdocs.R
@@ -30,6 +30,7 @@ theme_gdocs <- function(base_size=12, base_family="sans") {
           axis.ticks = element_blank(),
           panel.grid.major = element_line(colour = "#CCCCCC"),
           panel.grid.minor = element_blank(),
+          legend.background = element_rect(colour = NA),
           legend.key = element_rect(colour = NA),
           legend.position = "right",
           legend.direction = "vertical")


### PR DESCRIPTION
Stops gdocs.R from drawing a border around a legend