### PR TITLE
Change panel.margin to panel.spacing, and change legend.justification

### DIFF
--- a/R/theme-map.R
+++ b/R/theme-map.R
@@ -27,8 +27,7 @@ theme_map <- function(base_size = 9, base_family = "") {
           panel.background = element_blank(),
           panel.border = element_blank(),
           panel.grid = element_blank(),
-          panel.margin = unit(0, "lines"),
+          panel.spacing = unit(0, "lines"),
           plot.background = element_blank(),
-          legend.justification = c(0, 0),
-          legend.position = c(0, 0))
+          legend.justification = "right")
 }


### PR DESCRIPTION
The current version of theme_map doesn't work with the development version of ggplot2 that will go to CRAN soon. I've made what I think are the necessary changes for it to play nicely with the new way parameters for panel/legend work. Let me know if any of this needs to be changed!

Thank you so much for your work on this great, useful package; I use it all the time.