### PR TITLE
Update github installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Or, to install the development version from github, use the
 
 ```r
 library("devtools")
-install_github(c("hadley/ggplot2", "jrnold/ggthemes"))
+install_github(c("tidyverse/ggplot2", "jrnold/ggthemes"))
 ```
 
 


### PR DESCRIPTION
The ggplot2 repository changed from `hadley/ggplot2` to `tidyverse/ggplot2`.