### PR TITLE
Highcharts JS theme: set base_family default to sans-serif

### DIFF
--- a/R/hc.R
+++ b/R/hc.R
@@ -15,7 +15,7 @@
 #' @example inst/examples/ex-theme_hc.R
 #' @export
 theme_hc <- function(base_size = 12,
-                     base_family = "sans",
+                     base_family = "sans-serif",
                      bgcolor = "default") {
   bgcol <- ggthemes_data$hc$bg[bgcolor]
 


### PR DESCRIPTION
'sans' was giving me some issues on under Firefox 58.0.1, Win 7

https://developer.mozilla.org/en-US/docs/Web/CSS/font-family