### PR TITLE
fixing typo in `ordered-seqential`

### DIFF
--- a/R/tableau.R
+++ b/R/tableau.R
@@ -34,7 +34,7 @@
 #' @family colour tableau
 #' @example inst/examples/ex-tableau_color_pal.R
 tableau_color_pal <- function(palette = "Tableau 10",
-                              type = c("regular", "ordered-seqential",
+                              type = c("regular", "ordered-sequential",
                                        "ordered-diverging"),
                               direction = 1) {
   type <- match.arg(type)

--- a/docs/reference/tableau_color_pal.html
+++ b/docs/reference/tableau_color_pal.html
@@ -112,7 +112,7 @@
     </div>
 
     <pre class="usage"><span class='fu'>tableau_color_pal</span>(<span class='kw'>palette</span> <span class='kw'>=</span> <span class='st'>"Tableau 10"</span>, <span class='kw'>type</span> <span class='kw'>=</span> <span class='fu'>c</span>(<span class='st'>"regular"</span>,
-  <span class='st'>"ordered-seqential"</span>, <span class='st'>"ordered-diverging"</span>), <span class='kw'>direction</span> <span class='kw'>=</span> <span class='fl'>1</span>)</pre>
+  <span class='st'>"ordered-sequential"</span>, <span class='st'>"ordered-diverging"</span>), <span class='kw'>direction</span> <span class='kw'>=</span> <span class='fl'>1</span>)</pre>
     
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">

--- a/man/tableau_color_pal.Rd
+++ b/man/tableau_color_pal.Rd
@@ -5,7 +5,7 @@
 \title{Tableau Color Palettes (discrete)}
 \usage{
 tableau_color_pal(palette = "Tableau 10", type = c("regular",
-  "ordered-seqential", "ordered-diverging"), direction = 1)
+  "ordered-sequential", "ordered-diverging"), direction = 1)
 }
 \arguments{
 \item{palette}{Palette name. See Details for available palettes.}


### PR DESCRIPTION
replaced with `ordered-sequential`

Fixes #99