### PR TITLE
Add type argument to scale_colour_tableau and scale_fill_tableau so sequential and diverging scales can be used

### DIFF
--- a/R/tableau.R
+++ b/R/tableau.R
@@ -67,14 +67,18 @@ tableau_color_pal <- function(palette = "Tableau 10",
 #' @export
 #' @seealso \code{\link{tableau_color_pal}()} for references.
 #' @example inst/examples/ex-scale_color_tableau.R
-scale_colour_tableau <- function(palette = "Tableau 10", ...) {
-  discrete_scale("colour", "tableau", tableau_color_pal(palette), ...)
+scale_colour_tableau <- function(palette = "Tableau 10",
+                                 type = "regular",
+                                 ...) {
+  discrete_scale("colour", "tableau", tableau_color_pal(palette, type), ...)
 }
 
 #' @export
 #' @rdname scale_color_tableau
-scale_fill_tableau <- function(palette = "Tableau 10", ...) {
-  discrete_scale("fill", "tableau", tableau_color_pal(palette), ...)
+scale_fill_tableau <- function(palette = "Tableau 10",
+                               type = "regular",
+                               ...) {
+  discrete_scale("fill", "tableau", tableau_color_pal(palette, type), ...)
 }
 
 #' @export

--- a/tests/testthat/test-tableau.R
+++ b/tests/testthat/test-tableau.R
@@ -50,8 +50,32 @@ test_that("scale_colour_tableau works", {
   expect_is(scale_colour_tableau(), "ScaleDiscrete")
 })
 
+test_that("scale_colour_tableau works with diverging scales", {
+  expect_is(scale_colour_tableau(type = "ordered-diverging",
+                                 palette = "Orange-Blue Diverging"),
+            "ScaleDiscrete")
+})
+
+test_that("scale_colour_tableau works with sequential scales", {
+  expect_is(scale_colour_tableau(type = "ordered-sequential",
+                                 palette = "Blue-Green Sequential"),
+            "ScaleDiscrete")
+})
+
 test_that("scale_fill_tableau works", {
   expect_is(scale_fill_tableau(), "ScaleDiscrete")
+})
+
+test_that("scale_fill_tableau works with diverging scales", {
+  expect_is(scale_fill_tableau(type = "ordered-diverging",
+                               palette = "Orange-Blue Diverging"),
+            "ScaleDiscrete")
+})
+
+test_that("scale_fill_tableau works with sequential scales", {
+  expect_is(scale_fill_tableau(type = "ordered-sequential",
+                               palette = "Blue-Green Sequential"),
+            "ScaleDiscrete")
 })
 
 test_that("tableau_gradient_pal works", {


### PR DESCRIPTION
As described in #106. Adding the `type` argument to `scale_colour_tableau` and `scale_fill_tableau` allows the ordered and sequential scales to be selected.

Basic tests of this functionality are included, let me know if more in-depth tests are required.