### PR TITLE
Update scale_*_tableau docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Description: Some extra themes, geoms, and scales for 'ggplot2'.
 License: GPL-2
 URL: http://github.com/jrnold/ggthemes
 BugReports: http://github.com/jrnold/ggthemes
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1
 LazyData: true
 Language: en-US
 Encoding: UTF-8

--- a/R/tableau.R
+++ b/R/tableau.R
@@ -2,7 +2,7 @@
 #'
 #' Color palettes used in \href{http://www.tableausoftware.com/}{Tableau}.
 #'
-#' @details Tableau provides types of color palettes:
+#' @details Tableau provides three types of color palettes:
 #' \code{"regular"} (discrete, qualitative categories),
 #' \code{"ordered-sequential"}, and \code{"ordered-diverging"}.
 #'
@@ -56,11 +56,16 @@ tableau_color_pal <- function(palette = "Tableau 10",
   f
 }
 
-#' Tableau color scales
+#' Tableau color scales (discrete)
 #'
-#' Categorical color scales from Tableau.
+#' Categorical (qualitative) color scales used in Tableau.
+#' See \funclink{tableau_color_pal} for details.
+#' Use the function \funclink{scale_colour_gradient_tableau} for the sequential
+#' and \funclink{scale_colour_gradient2_tableau} for the diverging continuous
+#' color scales from Tableu.
 #'
 #' @inheritParams ggplot2::scale_colour_hue
+#' @param palette Palette name. See Details for available palettes.
 #' @inheritParams tableau_color_pal
 #' @family colour tableau
 #' @rdname scale_color_tableau
@@ -68,13 +73,16 @@ tableau_color_pal <- function(palette = "Tableau 10",
 #' @seealso \code{\link{tableau_color_pal}()} for references.
 #' @example inst/examples/ex-scale_color_tableau.R
 scale_colour_tableau <- function(palette = "Tableau 10", ...) {
-  discrete_scale("colour", "tableau", tableau_color_pal(palette), ...)
+  discrete_scale("colour", "tableau", tableau_color_pal(palette, "regular"),
+                 ...)
 }
 
 #' @export
 #' @rdname scale_color_tableau
-scale_fill_tableau <- function(palette = "Tableau 10", ...) {
-  discrete_scale("fill", "tableau", tableau_color_pal(palette), ...)
+scale_fill_tableau <- function(palette = "Tableau 10",
+                               type = "regular",
+                               ...) {
+  discrete_scale("fill", "tableau", tableau_color_pal(palette, "regular"), ...)
 }
 
 #' @export
@@ -123,6 +131,10 @@ scale_shape_tableau <- function(palette = "default", ...) {
 
 #' Tableau colour gradient palettes (continuous)
 #'
+#' Gradient color palettes using the diverging and sequential continous color
+#' palettes in Tableau. See \funclink{tableau_color_pal} for discrete color
+#' palettes.
+#'
 #' @param palette Palette name.
 #'  \itemize{
 #'  \item{\code{"ordered-sequential"}}{\Sexpr[results=rd]{ggthemes:::rd_optlist(names(ggthemes::ggthemes_data$tableau[["color-palettes"]][["ordered-sequential"]]))}}
@@ -155,7 +167,12 @@ tableau_div_gradient_pal <- function(palette = "Orange-Blue Diverging", ...) {
   tableau_gradient_pal(palette = palette, type = "ordered-diverging", ...)
 }
 
-#' Tableau sequential colour scale (continuous)
+#' Tableau sequential colour scales (continuous)
+#'
+#' Continuous color scales using the sequential color palettes in Tableau.
+#' See \funclink{scale_colour_tableau} for Tableau discrete color scales,
+#' and \funclink{scale_colour_gradient2_tableau} for diverging color
+#' scales.
 #'
 #' @export
 #' @inheritParams tableau_seq_gradient_pal
@@ -202,6 +219,10 @@ scale_color_continuous_tableau <- scale_colour_gradient_tableau
 scale_fill_continuous_tableau <- scale_fill_gradient_tableau
 
 #' Tableau diverging colour scales (continuous)
+#'
+#' Continuous color scales using the diverging color scales in Tableau.
+#' See \funclink{scale_colour_tableau} for Tabaleau discrete color scales,
+#' and \funclink{scale_colour_gradient_tableau} for sequential color scales.
 #'
 #' @inheritParams tableau_div_gradient_pal
 #' @inheritParams ggplot2::scale_colour_hue

--- a/man/macros/funclink.Rd
+++ b/man/macros/funclink.Rd
@@ -1,0 +1,1 @@
+\newcommand{\funclink}{\code{\link[=#1]{#1()}}}

--- a/man/scale_color_tableau.Rd
+++ b/man/scale_color_tableau.Rd
@@ -4,11 +4,11 @@
 \alias{scale_colour_tableau}
 \alias{scale_fill_tableau}
 \alias{scale_color_tableau}
-\title{Tableau color scales}
+\title{Tableau color scales (discrete)}
 \usage{
 scale_colour_tableau(palette = "Tableau 10", ...)
 
-scale_fill_tableau(palette = "Tableau 10", ...)
+scale_fill_tableau(palette = "Tableau 10", type = "regular", ...)
 
 scale_color_tableau(palette = "Tableau 10", ...)
 }
@@ -66,9 +66,15 @@ expand the scale by 5\% on each side for continuous variables, and by
 scales, "top" or "bottom" for horizontal scales}
   \item{super}{The super class to use for the constructed scale}
 }}
+
+\item{type}{Type of palette. One of \code{"regular"}, \code{"ordered-diverging"}, or \code{"ordered-sequential"}.}
 }
 \description{
-Categorical color scales from Tableau.
+Categorical (qualitative) color scales used in Tableau.
+See \funclink{tableau_color_pal} for details.
+Use the function \funclink{scale_colour_gradient_tableau} for the sequential
+and \funclink{scale_colour_gradient2_tableau} for the diverging continuous
+color scales from Tableu.
 }
 \examples{
 library("ggplot2")

--- a/man/scale_colour_gradient2_tableau.Rd
+++ b/man/scale_colour_gradient2_tableau.Rd
@@ -30,7 +30,9 @@ scale_color_gradient2_tableau(palette = "Orange-Blue Diverging", ...,
 colour bar, or \code{'legend'} for discrete colour legend.}
 }
 \description{
-Tableau diverging colour scales (continuous)
+Continuous color scales using the diverging color scales in Tableau.
+See \funclink{scale_colour_tableau} for Tabaleau discrete color scales,
+and \funclink{scale_colour_gradient_tableau} for sequential color scales.
 }
 \examples{
 library("ggplot2")

--- a/man/scale_colour_gradient_tableau.Rd
+++ b/man/scale_colour_gradient_tableau.Rd
@@ -6,7 +6,7 @@
 \alias{scale_color_gradient_tableau}
 \alias{scale_color_continuous_tableau}
 \alias{scale_fill_continuous_tableau}
-\title{Tableau sequential colour scale (continuous)}
+\title{Tableau sequential colour scales (continuous)}
 \usage{
 scale_colour_gradient_tableau(palette = "Blue", ...,
   na.value = "grey50", guide = "colourbar")
@@ -38,7 +38,10 @@ scale_fill_continuous_tableau(palette = "Blue", ...,
 colour bar, or \code{'legend'} for discrete colour legend.}
 }
 \description{
-Tableau sequential colour scale (continuous)
+Continuous color scales using the sequential color palettes in Tableau.
+See \funclink{scale_colour_tableau} for Tableau discrete color scales,
+and \funclink{scale_colour_gradient2_tableau} for diverging color
+scales.
 }
 \examples{
 library("ggplot2")

--- a/man/tableau_color_pal.Rd
+++ b/man/tableau_color_pal.Rd
@@ -19,7 +19,7 @@ colors. If -1, then reverse the order.}
 Color palettes used in \href{http://www.tableausoftware.com/}{Tableau}.
 }
 \details{
-Tableau provides types of color palettes:
+Tableau provides three types of color palettes:
 \code{"regular"} (discrete, qualitative categories),
 \code{"ordered-sequential"}, and \code{"ordered-diverging"}.
 

--- a/man/tableau_gradient_pal.Rd
+++ b/man/tableau_gradient_pal.Rd
@@ -25,7 +25,9 @@ tableau_div_gradient_pal(palette = "Orange-Blue Diverging", ...)
 \item{...}{Arguments passed to \code{tableau_gradient_pal}.}
 }
 \description{
-Tableau colour gradient palettes (continuous)
+Gradient color palettes using the diverging and sequential continous color
+palettes in Tableau. See \funclink{tableau_color_pal} for discrete color
+palettes.
 }
 \examples{
 library("scales")


### PR DESCRIPTION
Update docs for scale_*_tableau functions to include more cross references. Make it clear that there are three separate scales

-   `scale_colour_tableau`: discrete
-   `scale_colour_gradient_tableau`: continuous sequential
-   `scale_colour_gradient2_tableau`: continuous diverging

Fixes #107 
