### PR TITLE
Fix doc example error

### DIFF
--- a/inst/examples/ex-cleveland_shape_pal.R
+++ b/inst/examples/ex-cleveland_shape_pal.R
@@ -1,6 +1,6 @@
 ###   (discrete).
 
-
+\dontrun{
 library("ggplot2")
 p <- ggplot(mtcars) +
      geom_point(aes(x = wt, y = mpg, shape = factor(gear))) +
@@ -10,3 +10,4 @@ p <- ggplot(mtcars) +
 p + scale_shape_cleveland()
 # non-overlapping symbol palette
 p + scale_shape_cleveland(overlap = FALSE)
+}

--- a/man/cleveland_shape_pal.Rd
+++ b/man/cleveland_shape_pal.Rd
@@ -33,7 +33,7 @@ The palette \code{cleveland_shape_pal()} supports up to five values.
 \examples{
 ###   (discrete).
 
-
+\dontrun{
 library("ggplot2")
 p <- ggplot(mtcars) +
      geom_point(aes(x = wt, y = mpg, shape = factor(gear))) +
@@ -44,6 +44,7 @@ p + scale_shape_cleveland()
 # non-overlapping symbol palette
 p + scale_shape_cleveland(overlap = FALSE)
 }
+}
 \references{
 Cleveland WS. \emph{The Elements of Graphing Data}. Revised Edition. Hobart Press, Summit, NJ, 1994, pp. 154-164, 234-239.
 
@@ -51,7 +52,7 @@ Tremmel, Lothar, (1995) "The Visual Separability of Plotting Symbols in Scatterp
 \url{https://www.jstor.org/stable/1390760}
 }
 \seealso{
-Other shapes: 
+Other shapes:
 \code{\link{circlefill_shape_pal}()},
 \code{\link{scale_shape_circlefill}()},
 \code{\link{scale_shape_cleveland}()},


### PR DESCRIPTION
Fixes this by adding `\dontrun`.  Need a better long-run solution: #164 

```
❯ checking examples ... ERROR
  Running examples in ‘ggthemes-Ex.R’ failed
  The error most likely occurred in:
  
  > base::assign(".ptime", proc.time(), pos = "CheckExEnv")
  > ### Name: cleveland_shape_pal
  > ### Title: Shape palette from Cleveland "Elements of Graphing Data"
  > ###   (discrete).
  > ### Aliases: cleveland_shape_pal
  > 
  > ### ** Examples
  > 
  > ###   (discrete).
  > 
  > 
  > library("ggplot2")
  > p <- ggplot(mtcars) +
  +      geom_point(aes(x = wt, y = mpg, shape = factor(gear))) +
  +      facet_wrap(~am) +
  +      theme_bw()
  > # overlapping symbol palette
  > p + scale_shape_cleveland()
  > # non-overlapping symbol palette
  > p + scale_shape_cleveland(overlap = FALSE)
  Error in grid.Call.graphics(C_points, x$x, x$y, x$pch, x$size) : 
    conversion failure on '○' in 'mbcsToSbcs': for ○ (U+25CB)
  Calls: <Anonymous> ... drawDetails -> drawDetails.points -> grid.Call.graphics
  Execution halted
```