### PR TITLE
Fix docs errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,5 @@ repos:
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
-    -   id: trailing-whitespace
     -   id: 'no-commit-to-branch'
         args: ['--branch', 'main']

--- a/R/economist.R
+++ b/R/economist.R
@@ -125,7 +125,6 @@ scale_fill_economist <- function(...) {
 #' \itemize{
 #' \item \href{https://www.economist.com/}{The Economist}
 #' \item \href{https://spiekermann.com/en/itc-officina-display/}{Spiekerblog, "ITC Officina Display", January 1, 2007.}
-#' \item \url{https://www.economist.com/help/about-us}
 #' }
 #'
 #' @example inst/examples/ex-theme_economist.R

--- a/R/fivethirtyeight.R
+++ b/R/fivethirtyeight.R
@@ -1,7 +1,6 @@
 #' Theme inspired by FiveThirtyEight plots
 #'
-#' Theme inspired by the plots on
-#' \href{https://fivethirtyeight.com}{FiveThirtyEight}.
+#' Theme inspired by the plots from FiveThirtyEight.com.
 #'
 #' @inheritParams ggplot2::theme_grey
 #' @family themes fivethirtyeight

--- a/R/hc.R
+++ b/R/hc.R
@@ -4,7 +4,7 @@
 #'
 #' @references
 #'
-#' \url{https://www.highcharts.com/demo/line-basic}
+#' \url{https://www.highcharts.com/demo/highcharts/line-chart}
 #'
 #' @inheritParams ggplot2::theme_bw
 #' @param style The Highcharts theme to use \code{'default'},
@@ -65,7 +65,7 @@ theme_hc <- function(base_size = 12,
 #'
 #' \itemize{
 #'   \item{\href{https://www.highcharts.com/demo}{default}}
-#'   \item{\href{https://www.highcharts.com/demo/line-basic/dark-unica}{dark-unica}}
+#'   \item{\href{https://www.highcharts.com/demo/highcharts/line-chart}}
 #' }
 #'
 #' @param palette \code{character} The name of the Highcharts theme to use.

--- a/R/hc.R
+++ b/R/hc.R
@@ -61,14 +61,11 @@ theme_hc <- function(base_size = 12,
 #'
 #' @section Palettes:
 #'
-#' The following palettes are defined,
+#' The following palettes are defined:
 #'
-#' \itemize{
-#'   \item{\href{https://www.highcharts.com/demo}{default}}
-#'   \item{\href{https://www.highcharts.com/demo/highcharts/line-chart}}
-#' }
 #'
-#' @param palette \code{character} The name of the Highcharts theme to use.
+#' @param palette \code{character} The name of the Highcharts theme to use. One of
+#'  \code{"default"}, or \code{"darkunica"}.
 #'
 #' @family colour hc
 #' @export

--- a/R/wsj.R
+++ b/R/wsj.R
@@ -64,8 +64,7 @@ theme_wsj <- function(base_size = 12,
 #' The following palettes are defined,
 #'
 #' \describe{
-#' \item{rgby}{Red/Green/Blue/Yellow theme.
-#'   Examples: \url{https://twitpic.com/b2e3v2}. Up to four values.}
+#' \item{rgby}{Red/Green/Blue/Yellow theme.}
 #'   \item{red_green}{Green/red two-color scale for good/bad.}
 #' \item{green_black}{Black-green 4-color scale for 'Very negative',
 #'   'Somewhat negative', 'somewhat positive', 'very positive'.}

--- a/R/wsj.R
+++ b/R/wsj.R
@@ -66,15 +66,11 @@ theme_wsj <- function(base_size = 12,
 #' \describe{
 #' \item{rgby}{Red/Green/Blue/Yellow theme.
 #'   Examples: \url{https://twitpic.com/b2e3v2}. Up to four values.}
-#'   \item{red_green}{Green/red two-color scale for good/bad. Examples:
-#' \url{https://twitpic.com/b1avj6}, \url{https://twitpic.com/a4kxcl}.}
+#'   \item{red_green}{Green/red two-color scale for good/bad.}
 #' \item{green_black}{Black-green 4-color scale for 'Very negative',
-#'   'Somewhat negative', 'somewhat positive', 'very positive'.
-#'   Examples: \url{https://twitpic.com/awbua0}.}
-#' \item{dem_rep}{Democrat/Republican/Undecided blue/red/gray scale.
-#'   Examples: \url{https://twitpic.com/awbua0}.}
-#' \item{colors6}{Red, blue, gold, green, orange, and black palette.
-#'   Examples: \url{https://twitpic.com/9gfg5q}.}
+#'   'Somewhat negative', 'somewhat positive', 'very positive'.}
+#' \item{dem_rep}{Democrat/Republican/Undecided blue/red/gray scale.}
+#' \item{colors6}{Red, blue, gold, green, orange, and black palette.}
 #' }
 #'
 #' @param palette \code{character} The color palette to use: .

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -6,7 +6,7 @@
 -   "Note: found ... marked UTF-8 strings": The UTF strings are necessary to the package.
     They encode specific non-ASCII characters to use as symbols.
 
--   In `DESCRIPTION`, the words "Geoms", "Stata", "Tufte", "Tufte's", 
+-   In `DESCRIPTION`, the words "Geoms", "Stata", "Tufte", "Tufte's",
     and "geoms" are not misspelled.
 
 -   "Found the following (possibly) invalid URLs" check": The following URLs are valid.
@@ -14,10 +14,6 @@
 
     -   https://policyviz.com/2017/01/12/150-color-palettes-for-excel/ (Times out)
     -   https://spiekermann.com/en/itc-officina-display/ (libcurl error 38 "Connection timed out")
-    -   https://twitpic.com/9gfg5q (391, 503)
-    -   https://twitpic.com/awbua0 (391, 503)
-    -   https://twitpic.com/b1avj6 (391, 503)
-    -   https://twitpic.com/b2e3v2 (391, 503)
     -   https://twitter.com/WSJGraphics (400)
     -   https://www.canva.com/learn/ (403)
     -   https://www.canva.com/learn/100-color-combinations/ (403)

--- a/inst/examples/ex-calc_shape_pal.R
+++ b/inst/examples/ex-calc_shape_pal.R
@@ -1,5 +1,4 @@
-library("ggplot2")
-
 \dontrun{
+  library("ggplot2")
   show_shapes(calc_shape_pal()(13))
 }

--- a/inst/examples/ex-scale_shape_stata.R
+++ b/inst/examples/ex-scale_shape_stata.R
@@ -1,6 +1,8 @@
+\dontrun{
 library("ggplot2")
 
 p <- ggplot(mtcars) +
      geom_point(aes(x = wt, y = mpg, shape = factor(gear))) +
      facet_wrap(~am)
 p + theme_stata() + scale_shape_stata()
+}

--- a/inst/examples/ex-scale_shape_tableau.R
+++ b/inst/examples/ex-scale_shape_tableau.R
@@ -1,6 +1,8 @@
+\dontrun{
 library("ggplot2")
 
 p <- ggplot(mtcars) +
      geom_point(aes(x = wt, y = mpg, shape = factor(gear))) +
      facet_wrap(~am)
 p + scale_shape_tableau()
+}

--- a/inst/examples/ex-theme_calc.R
+++ b/inst/examples/ex-theme_calc.R
@@ -1,11 +1,14 @@
 library("ggplot2")
 
-p <- ggplot(mtcars) +
-     geom_point(aes(x = wt, y = mpg, colour = factor(gear))) +
-     facet_wrap(~am) + theme_calc()
-p + scale_color_calc()
-q <- ggplot(mtcars) +
-     geom_point(aes(x = wt, y = mpg, shape = factor(gear))) +
-     facet_wrap(~am) +
-     theme_calc()
-q + scale_shape_calc()
+ggplot(mtcars) +
+  geom_point(aes(x = wt, y = mpg, colour = factor(gear))) +
+  facet_wrap(~am) +
+  theme_calc() +
+  scale_color_calc()
+\dontrun{
+ggplot(mtcars) +
+  geom_point(aes(x = wt, y = mpg, shape = factor(gear))) +
+  facet_wrap(~am) +
+  theme_calc() +
+  scale_shape_calc()
+}

--- a/man/calc_shape_pal.Rd
+++ b/man/calc_shape_pal.Rd
@@ -10,9 +10,8 @@ calc_shape_pal()
 Shape palette based on the shapes used in LibreOffice Calc.
 }
 \examples{
-library("ggplot2")
-
 \dontrun{
+  library("ggplot2")
   show_shapes(calc_shape_pal()(13))
 }
 }

--- a/man/cleveland_shape_pal.Rd
+++ b/man/cleveland_shape_pal.Rd
@@ -52,7 +52,7 @@ Tremmel, Lothar, (1995) "The Visual Separability of Plotting Symbols in Scatterp
 \url{https://www.jstor.org/stable/1390760}
 }
 \seealso{
-Other shapes:
+Other shapes: 
 \code{\link{circlefill_shape_pal}()},
 \code{\link{scale_shape_circlefill}()},
 \code{\link{scale_shape_cleveland}()},

--- a/man/gdocs_pal.Rd
+++ b/man/gdocs_pal.Rd
@@ -16,7 +16,7 @@ library("scales")
 show_col(gdocs_pal()(24))
 }
 \seealso{
-Other colour gdocs:
+Other colour gdocs: 
 \code{\link{scale_fill_gdocs}()}
 }
 \concept{colour gdocs}

--- a/man/hc_pal.Rd
+++ b/man/hc_pal.Rd
@@ -25,7 +25,7 @@ The following palettes are defined,
 }
 
 \seealso{
-Other colour hc:
+Other colour hc: 
 \code{\link{scale_colour_hc}()}
 }
 \concept{colour hc}

--- a/man/hc_pal.Rd
+++ b/man/hc_pal.Rd
@@ -20,12 +20,12 @@ The following palettes are defined,
 
 \itemize{
   \item{\href{https://www.highcharts.com/demo}{default}}
-  \item{\href{https://www.highcharts.com/demo/line-basic/dark-unica}{dark-unica}}
+  \item{\href{https://www.highcharts.com/demo/highcharts/line-chart}}
 }
 }
 
 \seealso{
-Other colour hc: 
+Other colour hc:
 \code{\link{scale_colour_hc}()}
 }
 \concept{colour hc}

--- a/man/hc_pal.Rd
+++ b/man/hc_pal.Rd
@@ -7,7 +7,8 @@
 hc_pal(palette = "default")
 }
 \arguments{
-\item{palette}{\code{character} The name of the Highcharts theme to use.}
+\item{palette}{\code{character} The name of the Highcharts theme to use. One of
+\code{"default"}, or \code{"darkunica"}.}
 }
 \description{
 The Highcharts uses many different color palettes in its
@@ -16,12 +17,7 @@ plots. This collects a few of them.
 \section{Palettes}{
 
 
-The following palettes are defined,
-
-\itemize{
-  \item{\href{https://www.highcharts.com/demo}{default}}
-  \item{\href{https://www.highcharts.com/demo/highcharts/line-chart}}
-}
+The following palettes are defined:
 }
 
 \seealso{

--- a/man/scale_colour_gradient2_tableau.Rd
+++ b/man/scale_colour_gradient2_tableau.Rd
@@ -68,7 +68,7 @@ for (palette in head(names(palettes))) {
 p + scale_colour_gradient2_tableau(trans = "reverse")
 }
 \seealso{
-Other colour tableau:
+Other colour tableau: 
 \code{\link{scale_colour_gradient_tableau}()},
 \code{\link{scale_colour_tableau}()},
 \code{\link{tableau_color_pal}()},

--- a/man/scale_colour_gradient_tableau.Rd
+++ b/man/scale_colour_gradient_tableau.Rd
@@ -85,7 +85,7 @@ for (palette in head(names(palettes))) {
 }
 }
 \seealso{
-Other colour tableau:
+Other colour tableau: 
 \code{\link{scale_colour_gradient2_tableau}()},
 \code{\link{scale_colour_tableau}()},
 \code{\link{tableau_color_pal}()},

--- a/man/scale_hc.Rd
+++ b/man/scale_hc.Rd
@@ -13,7 +13,8 @@ scale_color_hc(palette = "default", ...)
 scale_fill_hc(palette = "default", ...)
 }
 \arguments{
-\item{palette}{\code{character} The name of the Highcharts theme to use.}
+\item{palette}{\code{character} The name of the Highcharts theme to use. One of
+\code{"default"}, or \code{"darkunica"}.}
 
 \item{...}{
   Arguments passed on to \code{\link[ggplot2:discrete_scale]{discrete_scale}}

--- a/man/scale_shape_stata.Rd
+++ b/man/scale_shape_stata.Rd
@@ -65,11 +65,13 @@ notation.
 See \code{\link{stata_shape_pal}()} for details.
 }
 \examples{
+\dontrun{
 library("ggplot2")
 
 p <- ggplot(mtcars) +
      geom_point(aes(x = wt, y = mpg, shape = factor(gear))) +
      facet_wrap(~am)
 p + theme_stata() + scale_shape_stata()
+}
 }
 \concept{shape stata}

--- a/man/scale_shape_tableau.Rd
+++ b/man/scale_shape_tableau.Rd
@@ -67,12 +67,14 @@ notation.
 See \code{\link{tableau_shape_pal}()} for details.
 }
 \examples{
+\dontrun{
 library("ggplot2")
 
 p <- ggplot(mtcars) +
      geom_point(aes(x = wt, y = mpg, shape = factor(gear))) +
      facet_wrap(~am)
 p + scale_shape_tableau()
+}
 }
 \seealso{
 Other shape tableau: 

--- a/man/tableau_color_pal.Rd
+++ b/man/tableau_color_pal.Rd
@@ -56,7 +56,7 @@ Factors in Computing Systems (CHI)
 \url{http://vis.stanford.edu/files/2012-ColorNameModels-CHI.pdf}.
 }
 \seealso{
-Other colour tableau:
+Other colour tableau: 
 \code{\link{scale_colour_gradient2_tableau}()},
 \code{\link{scale_colour_gradient_tableau}()},
 \code{\link{scale_colour_tableau}()},

--- a/man/tableau_gradient_pal.Rd
+++ b/man/tableau_gradient_pal.Rd
@@ -43,7 +43,7 @@ for (palname in names(palettes)) {
 }
 }
 \seealso{
-Other colour tableau:
+Other colour tableau: 
 \code{\link{scale_colour_gradient2_tableau}()},
 \code{\link{scale_colour_gradient_tableau}()},
 \code{\link{scale_colour_tableau}()},

--- a/man/theme_calc.Rd
+++ b/man/theme_calc.Rd
@@ -17,14 +17,17 @@ Theme similar to the default settings of LibreOffice Calc charts.
 \examples{
 library("ggplot2")
 
-p <- ggplot(mtcars) +
-     geom_point(aes(x = wt, y = mpg, colour = factor(gear))) +
-     facet_wrap(~am) + theme_calc()
-p + scale_color_calc()
-q <- ggplot(mtcars) +
-     geom_point(aes(x = wt, y = mpg, shape = factor(gear))) +
-     facet_wrap(~am) +
-     theme_calc()
-q + scale_shape_calc()
+ggplot(mtcars) +
+  geom_point(aes(x = wt, y = mpg, colour = factor(gear))) +
+  facet_wrap(~am) +
+  theme_calc() +
+  scale_color_calc()
+\dontrun{
+ggplot(mtcars) +
+  geom_point(aes(x = wt, y = mpg, shape = factor(gear))) +
+  facet_wrap(~am) +
+  theme_calc() +
+  scale_shape_calc()
+}
 }
 \concept{themes calc}

--- a/man/theme_economist.Rd
+++ b/man/theme_economist.Rd
@@ -97,7 +97,6 @@ p + theme_economist(base_family="Verdana") +
 \itemize{
 \item \href{https://www.economist.com/}{The Economist}
 \item \href{https://spiekermann.com/en/itc-officina-display/}{Spiekerblog, "ITC Officina Display", January 1, 2007.}
-\item \url{https://www.economist.com/help/about-us}
 }
 }
 \concept{themes economist}

--- a/man/theme_fivethirtyeight.Rd
+++ b/man/theme_fivethirtyeight.Rd
@@ -12,8 +12,7 @@ theme_fivethirtyeight(base_size = 12, base_family = "sans")
 \item{base_family}{base font family}
 }
 \description{
-Theme inspired by the plots on
-\href{https://fivethirtyeight.com}{FiveThirtyEight}.
+Theme inspired by the plots from FiveThirtyEight.com.
 }
 \examples{
 library("ggplot2")

--- a/man/theme_hc.Rd
+++ b/man/theme_hc.Rd
@@ -61,6 +61,6 @@ ggplot(dtemp, aes(x = months, y = temp, group = city, color = city)) +
   scale_fill_hc("darkunica")
 }
 \references{
-\url{https://www.highcharts.com/demo/line-basic}
+\url{https://www.highcharts.com/demo/highcharts/line-chart}
 }
 \concept{themes hc}

--- a/man/wsj_pal.Rd
+++ b/man/wsj_pal.Rd
@@ -34,7 +34,7 @@ The following palettes are defined,
 }
 
 \seealso{
-Other colour wsj:
+Other colour wsj: 
 \code{\link{scale_colour_wsj}()}
 }
 \concept{colour wsj}

--- a/man/wsj_pal.Rd
+++ b/man/wsj_pal.Rd
@@ -25,20 +25,16 @@ The following palettes are defined,
 \describe{
 \item{rgby}{Red/Green/Blue/Yellow theme.
   Examples: \url{https://twitpic.com/b2e3v2}. Up to four values.}
-  \item{red_green}{Green/red two-color scale for good/bad. Examples:
-\url{https://twitpic.com/b1avj6}, \url{https://twitpic.com/a4kxcl}.}
+  \item{red_green}{Green/red two-color scale for good/bad.}
 \item{green_black}{Black-green 4-color scale for 'Very negative',
-  'Somewhat negative', 'somewhat positive', 'very positive'.
-  Examples: \url{https://twitpic.com/awbua0}.}
-\item{dem_rep}{Democrat/Republican/Undecided blue/red/gray scale.
-  Examples: \url{https://twitpic.com/awbua0}.}
-\item{colors6}{Red, blue, gold, green, orange, and black palette.
-  Examples: \url{https://twitpic.com/9gfg5q}.}
+  'Somewhat negative', 'somewhat positive', 'very positive'.}
+\item{dem_rep}{Democrat/Republican/Undecided blue/red/gray scale.}
+\item{colors6}{Red, blue, gold, green, orange, and black palette.}
 }
 }
 
 \seealso{
-Other colour wsj: 
+Other colour wsj:
 \code{\link{scale_colour_wsj}()}
 }
 \concept{colour wsj}

--- a/man/wsj_pal.Rd
+++ b/man/wsj_pal.Rd
@@ -23,8 +23,7 @@ Collections of these plots can be found on the WSJ Graphics
 The following palettes are defined,
 
 \describe{
-\item{rgby}{Red/Green/Blue/Yellow theme.
-  Examples: \url{https://twitpic.com/b2e3v2}. Up to four values.}
+\item{rgby}{Red/Green/Blue/Yellow theme.}
   \item{red_green}{Green/red two-color scale for good/bad.}
 \item{green_black}{Black-green 4-color scale for 'Very negative',
   'Somewhat negative', 'somewhat positive', 'very positive'.}


### PR DESCRIPTION
Fix documentation errors in CRAN checks.

These were either: malformed Rd, bad links, or examples with unicode that had to have `\dontrun` added.