### PR TITLE
Refactor discrete_scale calls to use named arguments for palette

### DIFF
--- a/R/calc.R
+++ b/R/calc.R
@@ -54,13 +54,13 @@ calc_pal <- function() {
 #' @export
 #' @seealso See \code{\link{theme_calc}()} for examples.
 scale_fill_calc <- function(...) {
-  discrete_scale("fill", "calc", calc_pal(), ...)
+  discrete_scale("fill", palette = calc_pal(), ...)
 }
 
 #' @export
 #' @rdname scale_calc
 scale_colour_calc <- function(...) {
-  discrete_scale("colour", "calc", calc_pal(), ...)
+  discrete_scale("colour", palette = calc_pal(), ...)
 }
 
 #' @export
@@ -90,7 +90,7 @@ calc_shape_pal <- function() {
 #' @export
 #' @seealso \code{\link{theme_calc}()} for examples.
 scale_shape_calc <- function(...) {
-  discrete_scale("shape", "calc", calc_shape_pal(), ...)
+  discrete_scale("shape", palette = calc_shape_pal(), ...)
 }
 
 # PT_TO_MM <- 0.352778

--- a/R/canva.R
+++ b/R/canva.R
@@ -48,7 +48,7 @@ canva_pal <- function(palette = "Fresh and bright") {
 #' @inheritParams canva_pal
 #' @export
 scale_colour_canva <- function(..., palette = "Fresh and bright") {
-  discrete_scale("colour", "canva", canva_pal(palette), ...)
+  discrete_scale("colour", palette = canva_pal(palette), ...)
 }
 
 #' @export
@@ -58,5 +58,5 @@ scale_color_canva <- scale_colour_canva
 #' @export
 #' @rdname scale_colour_canva
 scale_fill_canva <- function(..., palette = "Fresh and bright") {
-  discrete_scale("fill", "canva", canva_pal(palette), ...)
+  discrete_scale("fill", palette = canva_pal(palette), ...)
 }

--- a/R/colorblind.R
+++ b/R/colorblind.R
@@ -24,7 +24,7 @@ colorblind_pal <- function() {
 #' @rdname colorblind
 #' @export
 scale_colour_colorblind <- function(...) {
-  discrete_scale("colour", "colorblind", colorblind_pal(), ...)
+  discrete_scale("colour", palette = colorblind_pal(), ...)
 }
 
 #' @rdname colorblind
@@ -34,5 +34,5 @@ scale_color_colorblind <- scale_colour_colorblind
 #' @rdname colorblind
 #' @export
 scale_fill_colorblind <- function(...) {
-  discrete_scale("fill", "colorblind", colorblind_pal(), ...)
+  discrete_scale("fill", palette = colorblind_pal(), ...)
 }

--- a/R/economist.R
+++ b/R/economist.R
@@ -112,7 +112,7 @@ economist_pal <- function(fill = TRUE) {
 #' @seealso \code{\link{theme_economist}()} for examples.
 #' @export
 scale_colour_economist <- function(...) {
-  discrete_scale("colour", "economist", economist_pal(), ...)
+  discrete_scale("colour", palette = economist_pal(), ...)
 }
 
 #' @rdname scale_economist
@@ -122,7 +122,7 @@ scale_color_economist <- scale_colour_economist
 #' @rdname scale_economist
 #' @export
 scale_fill_economist <- function(...) {
-  discrete_scale("fill", "economist", economist_pal(), ...)
+  discrete_scale("fill", palette = economist_pal(), ...)
 }
 
 #' ggplot color theme based on the Economist

--- a/R/excel.R
+++ b/R/excel.R
@@ -50,13 +50,13 @@ excel_new_pal <- function(theme = "Office Theme") {
 #' @export
 #' @example inst/examples/ex-theme_excel.R
 scale_fill_excel <- function(...) {
-  discrete_scale("fill", "excel", excel_pal(line = FALSE), ...)
+  discrete_scale("fill", palette = excel_pal(line = FALSE), ...)
 }
 
 #' @export
 #' @rdname scale_excel
 scale_colour_excel <- function(...) {
-  discrete_scale("colour", "excel", excel_pal(line = TRUE), ...)
+  discrete_scale("colour", palette = excel_pal(line = TRUE), ...)
 }
 
 #' @export
@@ -74,7 +74,7 @@ scale_color_excel <- scale_colour_excel
 #' @example inst/examples/ex-theme_excel_new.R
 #' @export
 scale_colour_excel_new <- function(theme = "Office Theme", ...) {
-  discrete_scale("colour", "excel_new", excel_new_pal(theme), ...)
+  discrete_scale("colour", palette = excel_new_pal(theme), ...)
 }
 
 #' @export
@@ -84,7 +84,7 @@ scale_color_excel_new <- scale_colour_excel_new
 #' @export
 #' @rdname scale_excel_new
 scale_fill_excel_new <- function(theme = "Office Theme", ...) {
-  discrete_scale("fill", "excel_new", excel_new_pal(theme), ...)
+  discrete_scale("fill", palette = excel_new_pal(theme), ...)
 }
 
 #' ggplot theme based on old Excel plots

--- a/R/few.R
+++ b/R/few.R
@@ -59,7 +59,7 @@ few_pal <- function(palette = "Medium") {
 #' @rdname scale_few
 #' @export
 scale_colour_few <- function(palette = "Medium", ...) {
-  discrete_scale("colour", "few", few_pal(palette), ...)
+  discrete_scale("colour", palette = few_pal(palette), ...)
 }
 
 #' @export
@@ -69,7 +69,7 @@ scale_color_few <- scale_colour_few
 #' @export
 #' @rdname scale_few
 scale_fill_few <- function(palette = "Light", ...) {
-  discrete_scale("fill", "few", few_pal(palette), ...)
+  discrete_scale("fill", palette = few_pal(palette), ...)
 }
 
 #' Theme based on Few's "Practical Rules for Using Color in Charts"
@@ -141,5 +141,5 @@ few_shape_pal <- function() {
 #'   scale uses.
 #' @export
 scale_shape_few <- function(...) {
-  discrete_scale("shape", "few", few_shape_pal(), ...)
+  discrete_scale("shape", palette = few_shape_pal(), ...)
 }

--- a/R/fivethirtyeight.R
+++ b/R/fivethirtyeight.R
@@ -63,7 +63,7 @@ fivethirtyeight_pal <- function() {
 #' @seealso \code{\link{theme_fivethirtyeight}()} for examples.
 #' @export
 scale_colour_fivethirtyeight <- function(...) {
-  discrete_scale("colour", "economist", fivethirtyeight_pal(), ...)
+  discrete_scale("colour", palette = fivethirtyeight_pal(), ...)
 }
 
 #' @rdname scale_fivethirtyeight
@@ -73,5 +73,5 @@ scale_color_fivethirtyeight <- scale_colour_fivethirtyeight
 #' @rdname scale_fivethirtyeight
 #' @export
 scale_fill_fivethirtyeight <- function(...) {
-  discrete_scale("fill", "economist", fivethirtyeight_pal(), ...)
+  discrete_scale("fill", palette = fivethirtyeight_pal(), ...)
 }

--- a/R/gdocs.R
+++ b/R/gdocs.R
@@ -113,13 +113,13 @@ gdocs_pal <- function() {
 #' @export
 #' @seealso See \code{\link{theme_gdocs}()} for examples.
 scale_fill_gdocs <- function(...) {
-  discrete_scale("fill", "gdocs", gdocs_pal(), ...)
+  discrete_scale("fill", palette = gdocs_pal(), ...)
 }
 
 #' @export
 #' @rdname scale_gdocs
 scale_colour_gdocs <- function(...) {
-  discrete_scale("colour", "gdocs", gdocs_pal(), ...)
+  discrete_scale("colour", palette = gdocs_pal(), ...)
 }
 
 #' @export

--- a/R/hc.R
+++ b/R/hc.R
@@ -89,7 +89,7 @@ hc_pal <- function(palette = "default") {
 #' @rdname scale_hc
 #' @export
 scale_colour_hc <- function(palette = "default", ...) {
-  discrete_scale("colour", "hc", hc_pal(palette), ...)
+  discrete_scale("colour", palette = hc_pal(palette), ...)
 }
 
 #' @rdname scale_hc
@@ -99,5 +99,5 @@ scale_color_hc <- scale_colour_hc
 #' @rdname scale_hc
 #' @export
 scale_fill_hc <- function(palette = "default", ...) {
-  discrete_scale("fill", "hc", hc_pal(palette), ...)
+  discrete_scale("fill", palette = hc_pal(palette), ...)
 }

--- a/R/pander.R
+++ b/R/pander.R
@@ -302,7 +302,7 @@ palette_pander <- function(n, random_order = FALSE) {
 #' @seealso \code{\link{theme_pander}()}
 #' @export
 scale_color_pander <- function(...) {
-  discrete_scale("colour", "pander", palette_pander, ...)
+  discrete_scale("colour", palette = palette_pander, ...)
 }
 
 
@@ -314,5 +314,5 @@ scale_colour_pander <- scale_color_pander
 #' @rdname scale_pander
 #' @export
 scale_fill_pander <- function(...) {
-  discrete_scale("fill", "pander", palette_pander, ...)
+  discrete_scale("fill", palette = palette_pander, ...)
 }

--- a/R/ptol.R
+++ b/R/ptol.R
@@ -34,7 +34,7 @@ ptol_pal <- function() {
 #' @export
 #' @example inst/examples/ex-scale_colour_ptol.R
 scale_colour_ptol <- function(...) {
-  discrete_scale("colour", "ptol", ptol_pal(), ...)
+  discrete_scale("colour", palette = ptol_pal(), ...)
 }
 
 #' @export
@@ -44,5 +44,5 @@ scale_color_ptol <- scale_colour_ptol
 #' @export
 #' @rdname scale_ptol
 scale_fill_ptol <- function(...) {
-  discrete_scale("fill", "ptol", ptol_pal(), ...)
+  discrete_scale("fill", palette = ptol_pal(), ...)
 }

--- a/R/shapes.R
+++ b/R/shapes.R
@@ -59,7 +59,7 @@ cleveland_shape_pal <- function(overlap = TRUE) {
 #' Hobart Press, Summit, NJ, 1994, pp. 154-164, 234-239.
 #'
 scale_shape_cleveland <- function(overlap = TRUE, ...) {
-  discrete_scale("shape", "cleveland", cleveland_shape_pal(overlap), ...)
+  discrete_scale("shape", palette = cleveland_shape_pal(overlap), ...)
 }
 
 #' Filled Circle Shape palette (discrete)
@@ -107,7 +107,7 @@ circlefill_shape_pal <- function() {
 #' \code{\link{circlefill_shape_pal}()} for a description of the palette.
 scale_shape_circlefill <- function(...) {
   deprecate_soft("5.0.0", "scale_shape_circlefill()")
-  discrete_scale("shape", "circlefill", circlefill_shape_pal(), ...)
+  discrete_scale("shape", palette = circlefill_shape_pal(), ...)
 }
 
 #' Shape palette from Tremmel (1995) (discrete)
@@ -178,8 +178,7 @@ tremmel_shape_pal <- function(overlap = FALSE, alt = FALSE) {
 scale_shape_tremmel <- function(overlap = FALSE, alt = TRUE, ...) {
   discrete_scale(
     "shape",
-    "tremmel",
-    tremmel_shape_pal(
+    palette = tremmel_shape_pal(
       overlap = overlap,
       alt = alt
     ),

--- a/R/solarized.R
+++ b/R/solarized.R
@@ -61,13 +61,13 @@ solarized_pal <- function(accent = "blue") {
 #' @export
 #' @example inst/examples/ex-scale_solarized.R
 scale_fill_solarized <- function(accent = "blue", ...) {
-  discrete_scale("fill", "solarized", solarized_pal(accent), ...)
+  discrete_scale("fill", palette = solarized_pal(accent), ...)
 }
 
 #' @export
 #' @rdname scale_solarized
 scale_colour_solarized <- function(accent = "blue", ...) {
-  discrete_scale("colour", "solarized", solarized_pal(accent), ...)
+  discrete_scale("colour", palette = solarized_pal(accent), ...)
 }
 #' @export
 #' @rdname scale_solarized

--- a/R/stata.R
+++ b/R/stata.R
@@ -30,13 +30,13 @@ stata_pal <- function(scheme = "s2color") {
 #' @rdname scale_stata
 #' @export
 scale_colour_stata <- function(scheme = "s2color", ...) {
-  discrete_scale("colour", "stata", stata_pal(scheme), ...)
+  discrete_scale("colour", palette = stata_pal(scheme), ...)
 }
 
 #' @export
 #' @rdname scale_stata
 scale_fill_stata <- function(scheme = "s2color", ...) {
-  discrete_scale("fill", "stata", stata_pal(scheme), ...)
+  discrete_scale("fill", palette = stata_pal(scheme), ...)
 }
 
 #' @export
@@ -316,7 +316,7 @@ stata_shape_pal <- function() {
 #' @example inst/examples/ex-scale_shape_stata.R
 #' @importFrom ggplot2 discrete_scale
 scale_shape_stata <- function(...) {
-  discrete_scale("shape", "stata", stata_shape_pal(), ...)
+  discrete_scale("shape", palette = stata_shape_pal(), ...)
 }
 
 #' Stata linetype palette (discrete)
@@ -345,7 +345,7 @@ stata_linetype_pal <- function() {
 #' @export
 #' @example inst/examples/ex-scale_linetype_stata.R
 scale_linetype_stata <- function(...) {
-  discrete_scale("linetype", "stata", stata_linetype_pal(), ...)
+  discrete_scale("linetype", palette = stata_linetype_pal(), ...)
 }
 
 ## Text sizes (from style definitions ado/base/style/gsize-*.style)

--- a/R/tableau.R
+++ b/R/tableau.R
@@ -85,13 +85,13 @@ tableau_color_pal <- function(
 #' @seealso \code{\link{tableau_color_pal}()} for references.
 #' @example inst/examples/ex-scale_color_tableau.R
 scale_colour_tableau <- function(palette = "Tableau 10", type = "regular", direction = 1, ...) {
-  discrete_scale("colour", "tableau", tableau_color_pal(palette, type, direction), ...)
+  discrete_scale("colour", palette = tableau_color_pal(palette, type, direction), ...)
 }
 
 #' @export
 #' @rdname scale_color_tableau
 scale_fill_tableau <- function(palette = "Tableau 10", type = "regular", direction = 1, ...) {
-  discrete_scale("fill", "tableau", tableau_color_pal(palette, type, direction), ...)
+  discrete_scale("fill", palette = tableau_color_pal(palette, type, direction), ...)
 }
 
 #' @export
@@ -135,7 +135,7 @@ tableau_shape_pal <- function(palette = c("default", "filled", "proportions")) {
 #' @family shape tableau
 #' @example inst/examples/ex-scale_shape_tableau.R
 scale_shape_tableau <- function(palette = "default", ...) {
-  discrete_scale("shape", "tableau", tableau_shape_pal(palette), ...)
+  discrete_scale("shape", palette = tableau_shape_pal(palette), ...)
 }
 
 # nolint start
@@ -203,7 +203,7 @@ scale_colour_gradient_tableau <- function(
   na.value = "grey50", # nolint: object_name_linter
   guide = "colourbar"
 ) {
-  continuous_scale("colour", "tableau", tableau_seq_gradient_pal(palette), na.value = na.value, guide = guide, ...)
+  continuous_scale("colour", palette = tableau_seq_gradient_pal(palette), na.value = na.value, guide = guide, ...)
 }
 
 #' @export
@@ -214,7 +214,7 @@ scale_fill_gradient_tableau <- function(
   na.value = "grey50", # nolint: object_name_linter
   guide = "colourbar"
 ) {
-  continuous_scale("fill", "tableau", tableau_seq_gradient_pal(palette), na.value = na.value, guide = guide, ...)
+  continuous_scale("fill", palette = tableau_seq_gradient_pal(palette), na.value = na.value, guide = guide, ...)
 }
 
 #' @export
@@ -249,7 +249,7 @@ scale_colour_gradient2_tableau <- function(
   na.value = "grey50", # nolint: object_name_linter
   guide = "colourbar"
 ) {
-  continuous_scale("colour", "tableau2", tableau_div_gradient_pal(palette), na.value = na.value, guide = guide, ...)
+  continuous_scale("colour", palette = tableau_div_gradient_pal(palette), na.value = na.value, guide = guide, ...)
 }
 
 #' @export
@@ -260,7 +260,7 @@ scale_fill_gradient2_tableau <- function(
   na.value = "grey50", # nolint: object_name_linter
   guide = "colourbar"
 ) {
-  continuous_scale("fill", "tableau2", tableau_div_gradient_pal(palette), na.value = na.value, guide = guide, ...)
+  continuous_scale("fill", palette = tableau_div_gradient_pal(palette), na.value = na.value, guide = guide, ...)
 }
 
 #' @export

--- a/R/wsj.R
+++ b/R/wsj.R
@@ -102,7 +102,7 @@ wsj_pal <- function(palette = "colors6") {
 #' @rdname scale_wsj
 #' @export
 scale_colour_wsj <- function(palette = "colors6", ...) {
-  discrete_scale("colour", "wsj", wsj_pal(palette), ...)
+  discrete_scale("colour", palette = wsj_pal(palette), ...)
 }
 
 #' @rdname scale_wsj
@@ -112,5 +112,5 @@ scale_color_wsj <- scale_colour_wsj
 #' @rdname scale_wsj
 #' @export
 scale_fill_wsj <- function(palette = "colors6", ...) {
-  discrete_scale("fill", "wsj", wsj_pal(palette), ...)
+  discrete_scale("fill", palette = wsj_pal(palette), ...)
 }


### PR DESCRIPTION
- Updated multiple scale functions across various files to use named arguments for the palette parameter in discrete_scale and continuous_scale functions.
- This change enhances code readability and consistency across the package's color and shape scaling functions.