### PR TITLE
chore: update theme functions to use 'linewidth' instead of 'size'

### DIFF
--- a/R/clean.R
+++ b/R/clean.R
@@ -20,12 +20,12 @@ theme_clean <- function(base_size = 12, base_family = "sans") {
     theme(
       axis.line.x = element_line(
         colour = "black",
-        size = 0.5,
+        linewidth = 0.5,
         linetype = "solid"
       ),
       axis.line.y = element_line(
         colour = "black",
-        size = 0.5,
+        linewidth = 0.5,
         linetype = "solid"
       ),
       axis.text = element_text(size = ceiling(base_size * 0.7), colour = "black"),

--- a/R/excel.R
+++ b/R/excel.R
@@ -164,7 +164,7 @@ theme_excel_new <- function(base_size = 9, base_family = "sans") {
       panel.grid.major = element_line(
         linetype = "solid",
         colour = colorlist$gray,
-        size = 0.75 * PT_TO_MM
+        linewidth = 0.75 * PT_TO_MM
       ),
       panel.grid.minor = element_blank(),
       axis.title = element_blank(),


### PR DESCRIPTION
- Refactored the theme functions in clean.R and excel.R to replace the 'size' argument with 'linewidth' for axis lines and grid lines, enhancing consistency with ggplot2's updated syntax.
- Fixes #184