### PR TITLE
Fix 301 status for a  URL

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggthemes (development version)
 
+- Bugfix: Fix 301 error in link (#196)
+
 # ggthemes 5.2.0
 
 - Renamed `scale_colour_colorblind()` to `scale_colour_colourblind()` (#180).

--- a/R/economist.R
+++ b/R/economist.R
@@ -135,7 +135,7 @@ scale_fill_economist <- function(...) {
 #'
 #' \code{theme_economist_white} implements a variant with a while
 #' panel and light gray (or white) background often used by \emph{The Economist}
-#' blog \href{https://www.economist.com/blogs/graphicdetail}{Graphic Detail}.
+#' blog \href{https://www.economist.com/topics/graphic-detail}{Graphic Detail}.
 #'
 #' Use \code{\link{scale_color_economist}()} with this theme.
 #' The x axis should be displayed on the right hand side.

--- a/man/theme_economist.Rd
+++ b/man/theme_economist.Rd
@@ -45,7 +45,7 @@ background theme in the print \emph{The Economist} and
 
 \code{theme_economist_white} implements a variant with a while
 panel and light gray (or white) background often used by \emph{The Economist}
-blog \href{https://www.economist.com/blogs/graphicdetail}{Graphic Detail}.
+blog \href{https://www.economist.com/topics/graphic-detail}{Graphic Detail}.
 
 Use \code{\link{scale_color_economist}()} with this theme.
 The x axis should be displayed on the right hand side.


### PR DESCRIPTION
Fixes:

Found the following (possibly) invalid URLs:
  URL: https://www.economist.com/blogs/graphicdetail (moved to https://www.economist.com/topics/graphic-detail)
    From: man/theme_economist.Rd
    Status: 301
    Message: Moved Permanently
For content that is 'Moved Permanently', please change http to https, add trailing slashes, or replace the old by the new URL.